### PR TITLE
Fix prometheus client config

### DIFF
--- a/lib/prometheus/client/configuration.rb
+++ b/lib/prometheus/client/configuration.rb
@@ -17,6 +17,7 @@ module Prometheus
         @multiprocess_files_dir = ENV.fetch('prometheus_multiproc_dir') do
           Dir.mktmpdir("prometheus-mmap")
         end
+        @enable_protobuf = false
       end
     end
   end

--- a/lib/prometheus/client/version.rb
+++ b/lib/prometheus/client/version.rb
@@ -1,5 +1,5 @@
 module Prometheus
   module Client
-    VERSION = '1.2.1'.freeze
+    VERSION = '1.2.2'.freeze
   end
 end


### PR DESCRIPTION
I added the gem to vinted-metrics and got this error:
```
 Vinted::Metrics::Middleware::Exporter.call GET /metrics/initialized has aggregations args
     Failure/Error: super(app, default_options)

     NoMethodError:
       undefined method `enable_protobuf' for #<Vinted::Metrics::Config:0x000000010b63e258 @logger=#<Logger:0x000000010b63e208 @level=0, @progname=nil,
```

I assume the default value is missing