### PR TITLE
add counter increment benchmark

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,3 +19,8 @@ group :test do
   gem 'rubocop', ruby_version?('< 2.0') ? '< 0.42' : nil
   gem 'tins', '< 1.7' if ruby_version?('< 2.0')
 end
+
+group :benchmark do
+  gem 'benchmark-ips'
+  gem 'benchmark-memory'
+end

--- a/Rakefile
+++ b/Rakefile
@@ -19,6 +19,8 @@ CLEAN.include FileList['**/*{.o,.so,.dylib,.bundle}'],
               FileList['**/Makefile'],
               FileList['pkg/']
 
+Rake.add_rakelib 'tasks'
+
 desc 'Default: run specs'
 task default: [:spec]
 

--- a/tasks/benchmark.rake
+++ b/tasks/benchmark.rake
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'benchmark/memory'
+require 'benchmark/ips'
+require 'prometheus/client'
+
+namespace :benchmark do
+  task :counter do
+    counter = Prometheus::Client::Counter.new(:counter, 'Benchmark counter')
+    counter_exemplar = Prometheus::Client::Counter.new(:counter_exemplar, 'Benchmark exemplar counter')
+
+    Benchmark.memory do |x|
+      x.report('counter.increment') { counter.increment }
+      x.report('counter_exemplar.increment') { counter_exemplar.increment({}, 1, 'trace_id', '123') }
+
+      x.compare!
+    end
+
+    Benchmark.ips do |x|
+      x.report('counter.increment') { counter.increment }
+      x.report('counter_exemplar.increment') { counter_exemplar.increment({}, 1, 'trace_id', '123') }
+
+      x.compare!
+    end
+  end
+
+  task :histogram do
+    histogram = Prometheus::Client::Histogram.new(:histogram, 'Benchmark histogram')
+    histogram_exemplar = Prometheus::Client::Histogram.new(:histogram_exemplar, 'Benchmark exemplar histogram')
+
+    Benchmark.memory do |x|
+      x.report('histogram.observe') { histogram.observe({}, 1) }
+      x.report('histogram_exemplar.observe') { histogram_exemplar.observe({}, 1, 'trace_id', '123') }
+
+      x.compare!
+    end
+
+    Benchmark.ips do |x|
+      x.report('histogram.observe') { histogram.observe({}, 1) }
+      x.report('histogram_exemplar.observe') { histogram_exemplar.observe({}, 1, 'trace_id', '123') }
+
+      x.compare!
+    end
+  end
+end


### PR DESCRIPTION
Adds a benchmarking rake task for comparing the memory usage and iteration-per-second for histograms & counters with and without exemplar arguments.